### PR TITLE
util: athena-run: use tmp directory, fix filetype

### DIFF
--- a/util/athena-run
+++ b/util/athena-run
@@ -1,9 +1,10 @@
 #!/bin/bash
-rm ${ATHENA_HOME}/athena-run-temp.ath
-echo "(load \""$1".ath\")" >>${ATHENA_HOME}/athena-run-temp.ath
-echo "quit" >>${ATHENA_HOME}/athena-run-temp.ath
-echo " " >>${ATHENA_HOME}/athena-run-temp.ath
-time ${ATHENA_HOME}/athena <${ATHENA_HOME}/athena-run-temp.ath
+TMPDIR=`dirname $(mktemp -u)`
+rm "$TMPDIR"/athena-run-temp.ath
+echo "(load \""$1"\")" >> "$TMPDIR"/athena-run-temp.ath
+echo "quit" >> "$TMPDIR"/athena-run-temp.ath
+echo " " >> "$TMPDIR"/athena-run-temp.ath
+time ${ATHENA_HOME}/athena < "$TMPDIR"/athena-run-temp.ath
 
 
 


### PR DESCRIPTION
Change `athena-run` shell script to use the system's `tmp` directory rather than the `ATHENA_HOME` directory.
Installing athena to `ATHENA_HOME` that is not writeable to all users, i.e. installing athena as a shared application, makes the `athena-run` script useless.
By using the system's `tmp` directory you are able to write the temporary file needed without having write access to `ATHENA_HOME`.

Fixes a filetype issue when trying to load a `.ath` file with `athena-run`. Using `athena-run` with `example.ath` results in athena loading `example.ath.ath`. Which is unintended behavior.