### PR TITLE
lib: basic: util.ath: add hsyl

### DIFF
--- a/lib/basic/util.ath
+++ b/lib/basic/util.ath
@@ -894,6 +894,15 @@ define (pairs->table L) :=
                              (!mp premise p))
                            (!from-complements false q (complement q)))))))))
 
+(define (hsyl premise-1 premise-2)
+  (dmatch [premise-1 premise-2]
+    ([(p1 ==> p2) (p2 ==> p3)]
+      (assume p1
+        (conclude p3
+          (!mp premise-2
+            (conclude p2
+            (!mp premise-1 p1))))))))
+
 (define (dsyl-1 premise-1 premise-2)
   (dmatch [premise-1 premise-2]
     ([(or p q) p'] 


### PR DESCRIPTION
Hypothetical syllogism is a rule defined in "Fundamental Proof Methods in Computer Science" p.215, but is not included in the language as part of `util.ath`.
`dsyl` is also defined on p.216 but is included.

Add `hsyl` to `util.ath` and implement as the book gives, but with `dmatch`.
This is useful for human written proofs, or exercises.