### PR TITLE
Thread-based TCP sockets

### DIFF
--- a/athena.mlb
+++ b/athena.mlb
@@ -5,6 +5,7 @@ local
 	$(SML_LIB)/mlyacc-lib/mlyacc-lib.mlb
         $(SML_LIB)/cml/cml.mlb
         $(SML_LIB)/basis/mlton.mlb	
+	$(SML_LIB)/smlnj-lib/INet/inet-lib.mlb
 in
 	compat_11072.sml
 	base.sig
@@ -82,7 +83,9 @@ in
 	semantics.sml
 	smt_output.sml
 	compiler.sml
+(**)
 	server.sml 
+(***)
 	topenv_part1.sml
 	topenv_part2.sml
 	definition_processor.sml
@@ -90,6 +93,7 @@ in
 	prolog_solver.sml
 	**)
 	repl.sml
+	mlton_server.sml
 	athena.sml
 	sml_c_util.sml
 	mlton_main.sml

--- a/athena.mlb
+++ b/athena.mlb
@@ -83,18 +83,16 @@ in
 	semantics.sml
 	smt_output.sml
 	compiler.sml
-(**)
 	server.sml 
-(***)
 	topenv_part1.sml
 	topenv_part2.sml
 	definition_processor.sml
-	(**
-	prolog_solver.sml
-	**)
 	repl.sml
 	mlton_server.sml
-	athena.sml
 	sml_c_util.sml
+(***
+	xsb_prolog_solver.sml
+***)
+	athena.sml
 	mlton_main.sml
 end

--- a/athena.sml
+++ b/athena.sml
@@ -65,5 +65,5 @@ fun main(arg0,args) =
      | [file_name] => M(SOME(file_name),false)
      | file_name::(_::_) => M(SOME(file_name),true))
    end
-   
+
 end 

--- a/base.sml
+++ b/base.sml
@@ -610,7 +610,7 @@ fun repeat n f =
 val (newline,lparen,rparen,lbrack,rbrack,lbrace,rbrace,
      blank,comma,period,colon,semi_colon,string_quote) = ("\n","(",")","[","]","{","}"," ",",",".",":",";","\"")
 
-fun mark(s) = (print("\n");repeat 3 (fn _ => print(s));print("\n"))
+fun mark(s) = (print("\n");repeat 10 (fn _ => print(s));print("\n"))
 
 fun failLst(messages) = raise FailLst messages
 

--- a/client.py
+++ b/client.py
@@ -13,6 +13,9 @@ def extract_response(sock):
         chunks.append(chunk)
     return b''.join(chunks).decode('utf-8')
 
+
+# Note: send_request_to_server_simple should only be used if the corresponding server uses readAllSimple.
+
 def send_request_to_server_simple(request: str, port=10000) -> str:
     server_address = 'localhost'
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
@@ -30,6 +33,12 @@ def send_request_to_server_simple(request: str, port=10000) -> str:
         except Exception as e:
             print(f"An error occurred: {e}")
             return ""
+
+# The default implementation of send_request_to_server encodes the size of the 
+# Athena payload into the first 4 bytes of the request (thus allowing payloads up to 4GB). 
+# This must be used in conjunction with readAll on the server side, which first extracts
+# the leading 4 bytes of the client's request, transforms those into the integer value N 
+# they represent, and then reads exactly N bytes from the connection. 
 
 def send_request_to_server(request: str, port=10000) -> str:
     server_address = 'localhost'
@@ -58,7 +67,6 @@ def spaces(i):
     else:
         return " " + spaces(i-1)
 
-# DEBUG: L[7]
 def checkProof(line):
 #
 # This function takes a string representing a line from a .jsonl file like gpt_and_english_proofs_230.jsonl 
@@ -80,10 +88,6 @@ def checkProof(line):
     else:
         return (True,athena_response)
 
-file = "../data/gpt_generated_athena_and_english_proofs_raw_data_230.ath"
-
-#L = getLines(file)
-
 def checkAll(file):
 #
 # This function works with an entire jsonl file like gpt_and_english_proofs_230.jsonl. It basically
@@ -99,9 +103,9 @@ def checkAll(file):
         R.append(response)
     return R
 
-# Example use: 
+# Example use (where file is a path like "../data/gpt_generated_athena_and_english_proofs_raw_data_230.ath"):
 # R = checkAll(file) 
-# This will give you all the successful/valid proofs: 
+# This will give all successful/valid proofs: 
 # T = [r for r in R if r[0]]
-# And this will give you all the incorrect proofs:
+# And this will give all incorrect proofs:
 # F = [r for r in R if not(r[0])]

--- a/client.py
+++ b/client.py
@@ -1,0 +1,107 @@
+import sys
+import socket
+import sys
+import json
+from utils import *
+
+def extract_response(sock):
+    chunks = []
+    while True:
+        chunk = sock.recv(40960)
+        if not chunk:  # Connection closed by server
+            break
+        chunks.append(chunk)
+    return b''.join(chunks).decode('utf-8')
+
+def send_request_to_server_simple(request: str, port=10000) -> str:
+    server_address = 'localhost'
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.settimeout(4)  # Set a 5-second timeout for demonstration
+        try:
+            sock.connect((server_address, port))
+            sock.sendall(request.encode('utf-8'))
+            sock.sendall(''.encode('utf-8'))
+            sock.shutdown(socket.SHUT_WR)
+            return extract_response(sock)
+        except socket.timeout:
+            print("Connection timed out.")
+            return ""
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return ""
+
+def send_request_to_server(request: str, port=10000) -> str:
+    server_address = 'localhost'
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.settimeout(4)
+        try:
+            sock.connect((server_address, port))
+            # Send length as 4-byte integer first
+            request_bytes = request.encode('utf-8')
+            length = len(request_bytes)
+            sock.sendall(length.to_bytes(4, byteorder='big'))
+            sock.sendall(request_bytes)
+            sock.shutdown(socket.SHUT_WR)
+            return extract_response(sock)
+        except socket.timeout:
+            print("Connection timed out.")
+            return ""
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return ""
+
+def spaces(i):
+    if i < 1:
+        return ""
+    else:
+        return " " + spaces(i-1)
+
+# DEBUG: L[7]
+def checkProof(line):
+#
+# This function takes a string representing a line from a .jsonl file like gpt_and_english_proofs_230.jsonl 
+# and checks whether or not the formal proof that can be found in that line is valid. If it is, it returns
+# a pair of the form (True,<theorem>), where the string <theorem> is a formula representing the conclusion of the proof.
+# If the proof is not valid, then the result is a pair of the form (False,<error message>), where the string <error message>
+# provides more detail on where exactly the proof went wrong, and what exactly was wrong (a syntax error, a logic error, and if
+# so, the type of error, etc.). 
+#
+    D = json.loads(line)
+    premises = D['premises']
+    goal = D['goal']
+    assumes = '\n'.join([spaces(index) + "assume premise-" + str(index+1) + " := " + premises[index] for index in range(len(premises))])
+    proof = assumes + "\nconclude " + goal + "\n" + D['ndlProof']
+    athena_response = send_request_to_server(proof)
+    athena_response_lower = athena_response.lower() 
+    if 'error' in athena_response_lower or 'failed' in athena_response_lower: 
+        return (False,athena_response)
+    else:
+        return (True,athena_response)
+
+file = "../data/gpt_generated_athena_and_english_proofs_raw_data_230.ath"
+
+#L = getLines(file)
+
+def checkAll(file):
+#
+# This function works with an entire jsonl file like gpt_and_english_proofs_230.jsonl. It basically
+# iterates the single-line function checkProof over all the contents of the jsonl file. The result
+# is a list of pairs (boolean_flag,<details>), as produced by checkProof, one for each line in the jsonl file.
+#
+    L = getLines(file)
+    R = []
+    send_request_to_server('declare A, B, C, D, E, F, G, H, J, I, K: Boolean')
+    for i in range(len(L)):
+        print("About to work on proof #" + str(i))
+        response = checkProof(L[i])        
+        R.append(response)
+    return R
+
+# Example use: 
+# R = checkAll(file) 
+# This will give you all the successful/valid proofs: 
+# T = [r for r in R if r[0]]
+# And this will give you all the incorrect proofs:
+# F = [r for r in R if not(r[0])]

--- a/make_athena_binary_for_linux
+++ b/make_athena_binary_for_linux
@@ -1,1 +1,1 @@
-mlton @MLton gc-summary -- -output ath -verbose 1 -default-ann 'allowFFI true' -drop-pass deepFlatten -codegen native athena.mlb
+mlton @MLton gc-summary -- -output athena -verbose 1 -default-ann 'allowFFI true' -drop-pass deepFlatten -codegen native athena.mlb

--- a/make_athena_binary_for_linux
+++ b/make_athena_binary_for_linux
@@ -1,0 +1,1 @@
+mlton @MLton gc-summary -- -output ath -verbose 1 -default-ann 'allowFFI true' -drop-pass deepFlatten -codegen native athena.mlb

--- a/make_athena_binary_for_mac
+++ b/make_athena_binary_for_mac
@@ -1,0 +1,1 @@
+mlton @MLton gc-summary -- -output ath -verbose 1 -default-ann 'allowFFI true' -drop-pass deepFlatten athena.mlb

--- a/make_athena_binary_for_mac
+++ b/make_athena_binary_for_mac
@@ -1,1 +1,1 @@
-mlton @MLton gc-summary -- -output ath -verbose 1 -default-ann 'allowFFI true' -drop-pass deepFlatten athena.mlb
+mlton @MLton gc-summary -- -output athena -verbose 1 -default-ann 'allowFFI true' -drop-pass deepFlatten athena.mlb

--- a/mlton_main.sml
+++ b/mlton_main.sml
@@ -1,13 +1,13 @@
 (*============================================================================================================
 
-Assuming that the executable you've produced by running makeBinaryLinux or makeBinaryMac is named "athena", 
-you can run Athena in a number of ways: 
+Assuming that the executable produced by running make_athena_binary_for_linux or make_athena_binary_for_mac 
+is named "athena", you can run the system in a number of ways: 
 
-./athena                                -> Starts the Athena REPL
-./athena foo.ath                        -> Loads foo.ath first and then starts the Athena REPL
-./athena foo.ath quit          	        -> Loads foo.ath and then quits 
-./athena -port <number>                 -> Starts an Athena TCP server running on port <number>
-./athena -port <number> -file foo.ath   -> Loads foo.ath and then starts an Athena TCP server on port <number>
+./athena                                -> Start the Athena REPL
+./athena foo.ath                        -> Load foo.ath first and then start the Athena REPL
+./athena foo.ath quit          	        -> Load foo.ath and then quit 
+./athena -port <number>                 -> Start an Athena TCP server running on port <number>
+./athena -port <number> -file foo.ath   -> Load foo.ath first and then start an Athena TCP server on port <number>
 
 ============================================================================================================*)
 

--- a/mlton_main.sml
+++ b/mlton_main.sml
@@ -7,7 +7,7 @@ fun express_main(arg0,args) =
 			    in
 			      if port_spec = "-p" orelse port_spec = "-port" then
   	  		        (case Int.fromString(port_value) of
-                                    SOME(p) => (Thread.spawn(fn () => AthenaServer.cmlMain(p)); Thread.run())
+                                    SOME(p) => (Thread.spawn(fn () => AthenaServer.startServer(p)); Thread.run())
  		                  | _ => Basic.fail("\nInvalid port number, an integer was expected.\n"))
                               else Basic.fail("\nPort option (-p or -port) expected as the first argument")
  			    end)

--- a/mlton_main.sml
+++ b/mlton_main.sml
@@ -1,1 +1,19 @@
-val _ = Athena.main("",CommandLine.arguments())
+fun express_main(arg0,args) =
+ let 
+     fun process() =  (case args of
+                          [arg1,arg2] =>
+			    let val [port_spec, port_value] = [arg1,arg2]
+			        val _ = Repl.init(NONE)
+			    in
+			      if port_spec = "-p" orelse port_spec = "-port" then
+  	  		        (case Int.fromString(port_value) of
+                                    SOME(p) => (Thread.spawn(fn () => AthenaServer.cmlMain(p)); Thread.run())
+ 		                  | _ => Basic.fail("\nInvalid port number, an integer was expected.\n"))
+                              else Basic.fail("\nPort option (-p or -port) expected as the first argument")
+ 			    end)
+     val _ = process()
+ in
+   OS.Process.success
+ end
+
+val _ = express_main("",CommandLine.arguments())

--- a/mlton_main.sml
+++ b/mlton_main.sml
@@ -1,19 +1,55 @@
-fun express_main(arg0,args) =
- let 
-     fun process() =  (case args of
-                          [arg1,arg2] =>
-			    let val [port_spec, port_value] = [arg1,arg2]
-			        val _ = Repl.init(NONE)
-			    in
-			      if port_spec = "-p" orelse port_spec = "-port" then
-  	  		        (case Int.fromString(port_value) of
-                                    SOME(p) => (Thread.spawn(fn () => AthenaServer.startServer(p)); Thread.run())
- 		                  | _ => Basic.fail("\nInvalid port number, an integer was expected.\n"))
-                              else Basic.fail("\nPort option (-p or -port) expected as the first argument")
- 			    end)
-     val _ = process()
- in
-   OS.Process.success
- end
+(*============================================================================================================
 
-val _ = express_main("",CommandLine.arguments())
+Assuming that the executable you've produced by running makeBinaryLinux or makeBinaryMac is named "athena", 
+you can run Athena in a number of ways: 
+
+./athena                                -> Starts the Athena REPL
+./athena foo.ath                        -> Loads foo.ath first and then starts the Athena REPL
+./athena foo.ath quit          	        -> Loads foo.ath and then quits 
+./athena -port <number>                 -> Starts an Athena TCP server running on port <number>
+./athena -port <number> -file foo.ath   -> Loads foo.ath and then starts an Athena TCP server on port <number>
+
+============================================================================================================*)
+
+
+fun mlton_main(arg0,args) = 
+  let fun M(file_name_option:string option,quit_after) =              
+             (print("\nWelcome to Athena!\n");
+              print("\nType an expression or deduction at the\nprompt below, ");
+              print("and press Enter to evaluate it.\n");
+	          print("\nTo exit Athena, type \"quit\" at the prompt\nand press Enter.\n");
+              if quit_after then
+                 Athena.runWithStarterFileAndQuit(file_name_option)
+	      else 		  
+                 Athena.runWithStarterFile(file_name_option);
+	      OS.Process.success) 
+(**      
+      val i = initializeXSB()
+**)
+  in
+    (case args of
+       [] => M(NONE,false)
+     | [file_name] => M(SOME(file_name),false)
+     | [arg_1,arg_2] => if arg_1 = "-port" orelse arg_1 = "--port" then
+                           let val port_num_opt = Int.fromString(arg_2)
+                           in
+                              (case port_num_opt of 
+                                  SOME(port_num) => (Thread.spawn(fn () => AthenaServer.startServer(port_num,NONE)); Thread.run(); OS.Process.success)
+                                | _ => (print("\nInvalid port number."); OS.Process.failure))
+                           end 
+                        else M(SOME(arg_1),true)          
+     | [arg_1,arg_2,arg_3,arg_4] =>  
+                       if (arg_1 = "-port" orelse arg_1 = "--port") andalso (arg_3 = "--file" orelse arg_3 = "-file") then
+                             let val port_num_opt = Int.fromString(arg_2)
+                                 val starter_file = arg_4
+                             in
+                                (case port_num_opt of 
+                                    SOME(port_num) => (Thread.spawn(fn () => AthenaServer.startServer(port_num,SOME(starter_file))); Thread.run(); OS.Process.success)
+                                  | _ => (print("\nInvalid port number."); OS.Process.failure))
+                             end
+                       else 
+                             M(SOME(arg_1),true)
+     | file_name::(_::_) => M(SOME(file_name),true))
+   end
+   
+val _ = mlton_main("",CommandLine.arguments())

--- a/repl.sml
+++ b/repl.sml
@@ -39,23 +39,6 @@ fun printLoadedFiles(loaded_files : (string,bool) HashTable.hash_table) =
   end
 
 fun debugPrint(_) = ()
-
-fun exceptionToString(e) =
- let fun f(ErrorMsg.ParseError((l,p),str)) = ("\n"^A.posToString({line=l,file=(!Paths.current_file),pos=p})^": Parsing error, "^str^".\n")
-       | f(A.LexError(str,SOME(pos))) = ("\n"^A.posToString(pos)^": Lexical error, "^str^".\n")
-       | f(A.LexError(str,NONE)) = ((!Paths.current_file)^": Lexical error at end of file, "^str^".\n")
-       | f(A.SyntaxError(str,SOME(pos))) = ("\n"^(A.posToString pos)^": Syntax error: "^str^".\n")
-       | f(A.SyntaxError(str,NONE)) = ("\n"^(!Paths.current_file)^": Syntax error: "^str^".\n")
-       | f(Semantics.AthenaError(msg)) = ("\n"^msg^"\n")
-       | f(Semantics.EvalError(x)) = Semantics.makeErrorWithPosInfo(x)
-       | f(Data.GenEx(str)) = str^"\n"
-       | f(SemanticValues.GenEx(x as (msg,pos_opt))) = Semantics.makeErrorWithPosInfo(x)
-       | f(Basic.Fail(str)) = "\n"^str^"\n"
-       | f(Basic.FailLst(strings)) = "\n"^(Basic.printListStr(strings,fn x => x, "\n"))^"\n" 
-       | f(_) = "\nUnknown error: "^(exnMessage e)
- in
-   f e
- end
             
 fun showFreeIds(phr,mod_path) = 
  let val (new_phrase,vars,fids) = preProcessPhrase(phr,mod_path)
@@ -140,7 +123,7 @@ in
                                         print(Semantics.summarizeTopCallStack()))
                                      end
      | TopEnv.Halt => ()     
-     | _ => print(exceptionToString(e)))
+     | _ => print(Semantics.exceptionToString(e)))
 end
            
 fun pathToString(path) = if null(path) then "[]" else Basic.printListStr(path,Symbol.name,".")
@@ -337,7 +320,7 @@ and processModuleExtension(module:A.module_entry as {module_name,module_contents
                        val _ = returned_env := SV.valEnv({val_map=val_map1',mod_map=Symbol.enter(mod_map1,mod_sym,new_module)})
                    in
                       eval_env := SV.valEnv({val_map=val_map2,mod_map=Symbol.enter(mod_map2,mod_sym,new_module)})
-                   end handle ex => (error_msg := exceptionToString(ex);
+                   end handle ex => (error_msg := Semantics.exceptionToString(ex);
                                      Paths.open_mod_paths := starting_open_mod_paths_val;
                                      Paths.open_mod_directives := starting_open_mod_directives_val;
                                      eval_env := starting_eval_env;
@@ -408,7 +391,7 @@ and processModule(module:A.module_entry as {module_name,module_contents,module_f
 				 else ()
                     in
                        ()
-                    end) handle ex => (error_msg := exceptionToString(ex);
+                    end) handle ex => (error_msg := Semantics.exceptionToString(ex);
                                        Paths.open_mod_paths := starting_open_mod_paths_val;
 				       Paths.open_mod_directives := starting_open_mod_directives_val;
                                        eval_env := starting_eval_env;
@@ -795,7 +778,7 @@ fun getInputAndProcess() =
                                   ((Parse.parse_from_stream istream),true,"") 
                                       handle e => let val _ = Parse.setLinePos(1,0)
                                                   in
-                                                    ([],false,exceptionToString(e))
+                                                    ([],false,Semantics.exceptionToString(e))
                                                   end
                      in
                        if ok_input then

--- a/repl.sml
+++ b/repl.sml
@@ -830,6 +830,7 @@ fun escape(str) =
      loop(L,[])
   end
        
+(**** qqq PROCESSSTRING DEFINITION ****)
 fun processString(cmd,mod_path,env,eval_env) =
     let val stream = TextIO.openString (cmd)
         val inputs  = Parse.parse_from_stream(stream)
@@ -839,6 +840,13 @@ fun processString(cmd,mod_path,env,eval_env) =
     end
 
 val _ = (Semantics.processString := processString)
+
+fun processAlreadyParsedInputs(inputs,mod_path,env,eval_env) =
+        let val _ = List.app (fn i => (processInput(i,mod_path,env, Semantics.top_val_env, N.top_level_name,top_loaded_files_ht))) inputs
+    in () 
+    end
+
+val _ = (Semantics.processAlreadParsedInputsRef := processAlreadyParsedInputs)
 
 fun makeLibFileName(home,fname) = List.foldl (fn (dir, path) => Paths.makePath(path, dir)) home ["lib", "basic", fname]
 

--- a/semantics.sml
+++ b/semantics.sml
@@ -34,6 +34,8 @@ val evaluateStringFlexible:((string * value_environment ref) -> value) ref = ref
 
 val processString:((string * (Symbol.symbol list) * value_environment ref * value_environment ref) -> unit) ref = ref (fn _ => ())
 
+val processAlreadParsedInputsRef :((A.user_input list * (Symbol.symbol list) * value_environment ref * value_environment ref) -> unit) ref = ref (fn _ => ())
+
 val (ABaseInsert,ABaseAugment) = (ABase.insert,ABase.augment)
 
 fun putValIntoAB(propVal(P),ab) = ABase.insert(P,ab)

--- a/semantics.sml
+++ b/semantics.sml
@@ -2205,6 +2205,23 @@ fun liftArg(arg_val,expected_arity,pos_opt) =
             end
          else evError(wrongArgKindExpectationOnly(termLCType,arg_val),pos_opt)
      | _ => evError(wrongArgKindExpectationOnly(termLCType,arg_val),pos_opt))
+
+fun exceptionToString(e) =
+ let fun f(ErrorMsg.ParseError((l,p),str)) = ("\n"^A.posToString({line=l,file=(!Paths.current_file),pos=p})^": Parsing error, "^str^".\n")
+       | f(A.LexError(str,SOME(pos))) = ("\n"^A.posToString(pos)^": Lexical error, "^str^".\n")
+       | f(A.LexError(str,NONE)) = ((!Paths.current_file)^": Lexical error at end of file, "^str^".\n")
+       | f(A.SyntaxError(str,SOME(pos))) = ("\n"^(A.posToString pos)^": Syntax error: "^str^".\n")
+       | f(A.SyntaxError(str,NONE)) = ("\n"^(!Paths.current_file)^": Syntax error: "^str^".\n")
+       | f(AthenaError(msg)) = ("\n"^msg^"\n")
+       | f(EvalError(x)) = makeErrorWithPosInfo(x)
+       | f(Data.GenEx(str)) = str^"\n"
+       | f(GenEx(x as (msg,pos_opt))) = makeErrorWithPosInfo(x)
+       | f(Basic.Fail(str)) = "\n"^str^"\n"
+       | f(Basic.FailLst(strings)) = "\n"^(Basic.printListStr(strings,fn x => x, "\n"))^"\n" 
+       | f(_) = "\nUnknown error: "^(exnMessage e)
+ in
+   f e
+ end
      
 val (lp,rp,space) = ("(",")"," ")
 

--- a/server.sml
+++ b/server.sml
@@ -2,6 +2,9 @@
 
 A function (Server.makeServerFun) that creates an Athena TCP server, which
 can be hit by any TCP client (written in any language), local or remote. 
+Note: This is a single-threaded server and its use is not recommended.
+For a robust Athena server, use MLton to generate an executable and then
+start a TCP server on the desired port as described in mlton_main.sml.
 
 =======================================================================*)
 

--- a/server.sml
+++ b/server.sml
@@ -25,7 +25,7 @@ fun makeServerFun([termVal(t),cv],env,ab) =
                                                               ".\nThe procedure must take a string and return a string."))
                                          end   
                 fun runServerFun([termVal(pt)],env,ab) = 
-                      let val serverFun = Socket.makeServer(input_buffer_size,processString) 
+                      let val serverFun = SocketImp.makeServer(input_buffer_size,processString) 
                           val port = (case AthTerm.getNumVal(pt) of
                                          SOME(A.int_num(p,_),_) => p
                                        | _ => primError("A port number (numeral) was expected here"))

--- a/sockets.sml
+++ b/sockets.sml
@@ -6,7 +6,7 @@ to implement an Athena server that can be hit by arbitrary TCP clients
 
 =======================================================================*)
 
-structure Socket = struct
+structure SocketImp = struct
 
 open TextIO
 

--- a/topenv_part2.sml
+++ b/topenv_part2.sml
@@ -3325,7 +3325,8 @@ fun processPhraseDirectlyFromString(str,env:SemanticValues.value_environment ref
                             let val stream = TextIO.openString (str)
                                 val inputs  = Parse.parse_from_stream(stream)
                                 val input = hd(inputs)
-                                val res_val = (case input of
+                                val (res_val, error_msg) = 
+                                            ((case input of
                                                   A.phraseInput(p) => let val mod_path = (case (!Paths.open_mod_paths) of
                                                                                              [] => []
                                                                                            | mp::_ => mp)
@@ -3350,9 +3351,10 @@ fun processPhraseDirectlyFromString(str,env:SemanticValues.value_environment ref
                                                             val _ = doInputs(inputs,(!Paths.current_mod_path),ref(!env),env)
                                                         in
                                                            unitVal
-							end)
+							end), "")
+                                                  handle e => (unitVal,Semantics.exceptionToString(e))
                             in 
-                               res_val
+                              if error_msg = "" then Semantics.prettyValToString(res_val) else error_msg
                             end
 
 

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,584 @@
+import sys, json, os, re
+import requests
+import random
+import numpy as np
+import pandas as pd 
+import time
+import tempfile
+import glob
+import importlib
+from pathlib import Path
+import yaml
+import pprint
+snlp = None
+
+def filenameStem(f):
+    return Path(f).stem
+
+def filenameExtension(f):
+    return Path(f).suffix
+
+def filenameDir(f):
+    (d,_) = os.path.split(f)
+    return d
+
+def pathFilename(f):
+    (_,f) = os.path.split(f)
+    return f
+
+def pp(x):
+    pp = pprint.PrettyPrinter(width=41, compact=True)
+    pp.pprint(x)
+
+#========================== Uncomment the following 5 lines to get isEnglishWord working.... 
+# nltk.download('words')
+# nltk.download('wordnet')
+# ps = PorterStemmer()
+# lemmatizer = WordNetLemmatizer()
+# english_words = set(words.words())
+
+def isEnglishWord(word,normalization='stemming'):
+    #Note: Stemming works better than lemmatization (e.g., the latter fails to get 'inhibiting').
+    stem = ps.stem(word.lower())
+    lemmatized_word = lemmatizer.lemmatize(word)
+    return word in english_words or spell.correction(word) == word or stem in english_words or lemmatized_word in english_words
+
+def segmentSentences(text):
+    doc = snlp(text)
+    return [sentence.text for sentence in doc.sentences]
+
+def pos(text):
+    doc = snlp(text)
+    return [(word,word.pos) for sent in doc.sentences for word in sent.words]
+
+def hasVerb(text):
+    return not(all([(p[1] != 'VERB') for p in pos(text)]))
+
+def hasNoun(text):
+    return not(all([(p[1] != 'NOUN' and p[1] != 'PROPN') for p in pos(text)]))
+
+def zipLists(L1,L2):
+    m = min(len(L1),len(L2))
+    res = []
+    for i in range(m):
+        res.append((L1[i],L2[i]))
+    return res 
+    
+def unzipFile(f):
+    os.system("unzip " + f)
+
+def getAllFiles(dir):
+    return [f for f in os.listdir(dir) if os.path.isfile(os.path.join(dir, f))]
+
+def getAllFilesRecursively(dir):
+    files = []
+    path = Path(dir).resolve()
+    for file in path.rglob('*'):
+        if file.is_file():
+            files.append(str(file))
+    return files
+
+def getAllSubDirsRecursively(dir):
+    files = []
+    path = Path(dir).resolve()
+    for file in path.rglob('*'):
+        if not(file.is_file()):
+            files.append(str(file))
+    return files
+
+def highlightSection(s,i,j,window=20):
+    return f"{s[(i-window):i]}\033[1;32;40m{s[i:j]}\033[m{s[j:(j+window)]}"
+
+def findSubstringOccsBounded(pat, base, a, b):
+    slice_base = base[a:b]
+    indices = []
+    start = 0
+    while start < len(slice_base):
+        pos = slice_base.find(pat, start)
+        if pos != -1:  # if substring found
+            indices.append(pos+a)  # adjust index relative to original string
+            start = pos + len(pat)  # start next search after this substring
+        else:
+            start += 1
+    return indices
+
+def findSubstringOccsBoundedAccum(pat,base,a,b,results):
+    if a >= b:
+        return results
+    i = base.find(pat,a)
+    return results if i < 0 or i > b else findSubstringOccsBoundedAccum(pat,base,i+len(pat),b,[i] + results)
+
+def findSubstringOccsBounded(pat,base,a,b):
+    return list(reversed(findSubstringOccsBoundedAccum(pat,base,a,b,[])))
+    
+def findAndShowAllRegexOccurrences(p,s,window=20,show=True,msg=""):
+# Print the list of all (start,end) occurrences of regex pattern p inside the string s, and then return that list. 
+    matches = re.finditer(p,s)
+    range_pairs = [(match.start(), match.end()) for match in matches]
+    counter = 0
+    for (start,end) in range_pairs:
+        counter += 1
+        if show:
+            print(msg + "Match #" + str(counter) + ": (" + str(start) + ", " + str(end) + ") --> " + highlightSection(s,start,end,window))
+    return range_pairs
+
+def findAllRegexOccurrences(p,s,window=20,show=True,msg=""):
+# Find the list of all (start,end) occurrences of regex pattern p inside the string s, and then return that list. 
+    matches = re.finditer(p,s)
+    range_pairs = [(match.start(), match.end()) for match in matches]
+    return range_pairs
+
+def copies(s,n):
+    return '' if n < 1 else s + copies(s,n-1)
+
+def insertString(base_string,new_string,pos):
+    return base_string[:pos] + new_string + base_string[pos:]
+
+import re
+
+def findFlex(s, s1):
+    s1_pattern = '\s*'.join(s1.split())
+    matches = re.finditer(s1_pattern, s)
+    return [match.start() for match in matches]
+
+google_Search_API_key = "AIzaSyAs7rHGHbSrOdiQ3ZvOQ8B3ji_jR298mhQ"
+
+google_search_engine_id = "964d901822ec646e8"
+
+def readChar():
+    print("Press Enter...")
+    return sys.stdin.read(1)
+
+def googleSearch(search_term, **kwargs):
+    url = "https://www.googleapis.com/customsearch/v1"
+    params = {
+        'q': search_term,
+        'key': google_Search_API_key,
+        'cx': google_search_engine_id,
+        **kwargs
+    }
+    response = requests.get(url, params=params)
+    return response.json()
+
+def googleSearchTotalResultNumber(search_term, **kwargs):
+    url = "https://www.googleapis.com/customsearch/v1"
+    params = {
+        'q': search_term,
+        'key': google_Search_API_key,
+        'cx': google_search_engine_id,
+        **kwargs
+    }
+    response = requests.get(url, params=params)
+    response_json = response.json()
+    if "spelling" in response_json:
+        auto_corrected = response_json['spelling']['correctedQuery'] 
+    else:
+        auto_corrected = ''
+    return {'result_count':int(response_json['searchInformation']['totalResults']),
+            'auto_corrected': auto_corrected}
+
+def googleKnowledeGraphQueryResults(query):
+    service_url = "https://kgsearch.googleapis.com/v1/entities:search"
+    params = {
+        "query": query,
+        "limit": 10,
+        "indent": True,
+        "key": google_Search_API_key
+    }
+    response = requests.get(service_url, params=params)
+    response_json = response.json()
+    #for element in response_json["itemListElement"]:
+    #   print(json.dumps(element, indent=2))
+    return response_json 
+
+def googleKnowledeGraphQuery(query):
+    D = googleKnowledeGraphQueryResults(query)
+    if len(D) > 0 and 'itemListElement' in D:
+        top_result = D['itemListElement'][0]
+        return json.dumps(top_result, indent=2)
+    else:
+        print("No results found")
+        return ''
+    
+def list_files(directory):
+    path = Path(directory)
+    for file in path.rglob('*'):
+        print(file)
+
+# Replace 'your_directory_path' with the path to the directory you want to traverse
+list_files('your_directory_path')
+
+def loopOverFiles(directory,processFile):    
+    for filename in os.listdir(directory):
+        f = os.path.join(directory, filename)
+        if os.path.isfile(f):
+            print("About to process this file: " + f)
+            processFile(f)
+            
+def readFileAsString(filename):
+    text_file = open(filename, "r")
+    data = text_file.read()
+    text_file.close()
+    return data
+
+def getNonStrippedLiteralLines(filename):
+    with open(filename) as f:
+        content = f.readlines()
+    L = [l for l in content]        
+    return L
+
+def getLines(filename):
+    with open(filename,errors='replace') as f:
+        content = f.readlines()
+    L = [l.strip() for l in content if l]
+    return [l for l in L if l]
+
+def getLiteralLines(filename):
+    with open(filename) as f:
+        content = f.readlines()
+    L = [l.strip() for l in content]        
+    return L
+
+def getTotallyLiteralLines(filename):
+    L = []
+    with open(filename) as f:
+        L = f.readlines()
+    return L
+
+def filterOutLines(file,filterOut):
+    return [l for l in getLines(file) if not(filterOut(l))]
+
+def filterLines(file,filter):
+    return [l for l in getLines(file) if filter(l)]
+
+def replaceLines(filename,replacementFunction):
+    L = getLines(filename)
+    res = []
+    for l in L:
+        l1 = l
+        try:
+            l1 = replacementFunction(l)
+        except:
+            pass
+        res.append(l1)
+    return res
+
+def writeFile(L,filename):
+    with open(filename, 'w') as f:
+        for item in L:
+            f.write("%s\n" % item)    
+
+def writeStringToFile(s,filename):
+    file = open(filename,"wt")
+    n = file.write(s)
+    file.close()
+
+def removeMultipleNewlines(f_in,f_out):
+    L = getNonStrippedLiteralLines(f_in)
+    R = []
+    for i in range(len(L)):
+        if L[i].strip() == '':
+            if i > 0 and L[i-1].strip() == '':
+                pass
+            else:
+                R.append(L[i])
+        else:
+            R.append(L[i])
+    writeStringToFile(''.join(R),f_out)
+    
+def appendToFile(s,filename):
+    with open(filename, "a") as myfile:
+        myfile.write(s)
+
+def dedupFile(f):
+    D = {}
+    L = getLines(f)
+    for l in L:
+        if not(l in D):
+            D[l] = True
+    writeFile(D.keys(),f + "_deduped.txt")
+
+def getJsonLines(file):
+    L = getLines(file)
+    dicts = []
+    for l in L:
+        D = json.loads(l)
+        dicts.append(D)
+    return dicts
+
+def processPatterns(premise_sentences,row_start,row_end):
+    R = {}
+    total = 0
+    for i in range(row_start,row_end):
+        if i > 0 and i % 500 == 0:
+            total += 500
+            print("Processed " + str(total) + " records...")
+        for s in premise_sentences:
+            if s in df.loc[i]['TEXT']:
+                R[s] = df.loc[i]['ROW_ID']        
+    return R
+
+
+def doItPlain(source,target,N=20000):
+    start = time.time()
+    for i in range(N):
+        res = target in source
+    end = time.time()
+    return (end-start)    
+
+def doItTrie(source,target,N=20000):
+    A = ahocorasick.Automaton()
+    sentences = source.split(".")
+    index = 0
+    for s in sentences:
+        A.add_word(s,(index,s))
+        index += 1
+    start = time.time()        
+    for i in range(N):
+        res = target in A
+    end = time.time()        
+    return (end-start)
+
+def compareTimes(source,target,N=20000):
+    times_to_repeat = 100
+    plain_times = []
+    for _ in range(times_to_repeat):
+        plain_times.append(doItPlain(source,target,N))
+    plain_time = np.mean(plain_times)
+    trie_times = []
+    for _ in range(times_to_repeat):   
+        trie_times.append(doItTrie(source,target,N))
+    trie_time = np.mean(trie_times)                            
+    q = plain_time/trie_time
+    print("Plain time: " + str(plain_time) + ", trie time: " + str(trie_time) + ", quotient: " + str(q))
+
+def process(premise_sentences,row_start,row_end,out_file="results_out.txt"):
+    R = processPatterns(premise_sentences,row_start,row_end)
+    L = []
+    for s in R:
+        L.append(s + " ||| " + str(R[s]))
+    writeFile(L,out_file)
+    print("\nDone, found " + str(len(L)) + " entries...\n")
+    return R
+
+def construct_prompt(instruction, input_text):
+    instruction = instruction.strip()
+    input_text = input_text.strip()
+    if not instruction:
+        return ""
+    if input_text:
+        prompt = f"Below is an instruction that describes a task, paired with an input that provides further context. Write a response that appropriately completes the request.\n\n### Instruction:\n{instruction}\n\n### Input:\n{input_text}\n\n### Response:"
+    else:
+        prompt = f"Below is an instruction that describes a task. Write a response that appropriately completes the request.\n\n### Instruction:\n{instruction}\n\n### Response:"
+    return prompt
+
+def aboutRight(cutpoint_delta,first):
+    if first:
+        return cutpoint_delta > 2200
+    else:
+        return cutpoint_delta > 1700        
+        
+def addNewPart(s,last_cutpoint,i,parts):
+    new_part = {'start':last_cutpoint,
+                'end':i}
+    parts.append(new_part)
+                
+def partSize(part):
+    return part['end'] - part['start']
+
+def tooSmall(part):
+    return partSize(part) < 500
+
+def spaces(n):
+    return "" if n < 1 else (" " + spaces(n-1))
+
+def getProperty(s):
+    return s.split("-")[0].lower()
+
+def getArgument(s):
+    return s.split(":")[1]
+
+def inRange(x,a,b):
+    return x >= a and x < b
+
+def fallInside(spans,chunk):
+    start,end = chunk['start'],chunk['end']
+    for (a,b) in spans:
+        if not(inRange(a,start,end)) or not(inRange(b,start,end)):
+            return False
+    return True
+        
+def isBracket(s):
+    return s == "[" or s == "]"
+
+def makeTextFileName(ann_file_name):
+    toks = ann_file_name.split(".")
+    res = (''.join(toks[:len(toks)-1])) + ".txt"
+    return res
+
+def findFirst(L,pred):
+    for x in L:
+        if pred(x):
+            return x
+    return None
+
+def writeAll(examples,out_file):
+    s = examplesToString(examples)
+    writeStringToFile(s,out_file)    
+    
+def null_intersection(L1,L2):
+     I = set(L1).intersection(set(L2))
+     if I:
+         return False
+     return True        
+
+def non_null_intersection(L1,L2): 
+    return not(null_intersection(L1,L2))
+
+def sleepFor(seconds):
+    time.sleep(seconds)
+
+def processAllFiles(directory,file_pattern,processor):
+    file_pattern = directory + "/" + file_pattern
+    all_matching_files = glob.glob(file_pattern)
+    N = len(all_matching_files)
+    print_progress = False
+    if N > 1000:
+        print_progress = True
+        print("Will process " + str(N) + " files in " + directory + ".")
+    counter = 0
+    for file in all_matching_files:
+        processor(file)        
+        counter += 1
+        if counter % 100 == 0:
+            print("Processed " + str(counter) + " files so far, " + str(N-counter) + " to go...")
+
+def forall(L,pred):
+    for x in L:
+        if not(pred(x)):
+            return False
+    return True
+
+def forSome(L,pred):
+    for x in L:
+        if pred(x):
+            return True
+    return False
+
+def tokenize(input_string, usual_delimiters, delimiters_to_keep):
+    # Escaping delimiters
+    usual_delimiters = [re.escape(d) for d in usual_delimiters]
+    delimiters_to_keep = [re.escape(d) for d in delimiters_to_keep]
+    # Creating regex
+    usual_regex = '|'.join(usual_delimiters)
+    keep_regex = '({})'.format('|'.join(delimiters_to_keep))
+    # Splitting string
+    tokens = re.split(usual_regex, input_string)
+    # Splitting tokens again, keeping the delimiters
+    tokens = [re.split(keep_regex, t) for t in tokens]
+    # Flattening list of tokens and removing empty strings
+    tokens = [t for sublist in tokens for t in sublist if t]
+    return tokens
+
+
+def isPunctChar(c):
+    return c in ['(', ')', '[', ']', '.', ':', ',']
+
+def isEnglishWordModuloPunctuationAux(t1,t2):
+    google_search_result_threshold = 10
+    #t1 ends with '-' and t2 is a word, but might end in punctuation, e.g. a comma.
+    #Also, t1 might start with something like a parenthesis.
+    s1 = t1[:-1] # Drop the dash at the end of t1 
+    s2 = t2
+    # if t1 starts with a punctuation character:
+    if isPunctChar(t1[0]): 
+        s1 = t1[1:]
+    # if t2 ends with a punctuation character:        
+    if isPunctChar(t2[-1]):
+        s2 = t2[:-1]
+    joined_option_minus_hyphen = s1 + s2
+    joined_option_with_hyphen = s1 + '-' + s2
+    hits_minus_hyphen = googleSearchTotalResultNumber(joined_option_minus_hyphen)['result_count']
+    hits_with_hyphen = googleSearchTotalResultNumber(joined_option_minus_hyphen)['result_count']
+    return (hits_minus_hyphen > 10 and hits_minus_hyphen > hits_with_hyphen) or (hits_minus_hyphen > 2000000000 and hits_minus_hyphen >= hits_with_hyphen)
+
+def isEnglishWordModuloPunctuation(t1,t2):
+    try:
+        return isEnglishWordModuloPunctuationAux(t1,t2)
+    except:
+        return False 
+    
+def joinHyphenatedWordsAux(L):
+    R = []
+    iteration = 0
+    for l in L:
+        line = l
+        if l.endswith('\n'):
+            l = l[:-1]
+        iteration += 1
+        if iteration % 200 == 0:
+            print("On line: " + str(iteration))
+        toks = l.split(' ')
+        new_toks = []
+        N = len(toks)
+        i = 0
+        while i < N:
+            t = toks[i]
+            if t.endswith("-"):
+                if i < N-1 and isEnglishWordModuloPunctuation(t,toks[i+1]): 
+                    joined = t[:-1] + toks[i+1]
+                    print("About to replace '" + t + " " + toks[i+1] + "' with: " + joined)
+                    new_toks.append(joined)
+                    i += 2
+                else:
+                    new_toks.append(t)
+                    i += 1
+            else:
+                new_toks.append(t)
+                i += 1
+        new_line = ' '.join(new_toks)
+        if line.endswith('\n'):
+            new_line = new_line + '\n'
+        R.append(new_line)
+    return R
+
+def joinHyphenatedWords(file):
+    L = getNonStrippedLiteralLines(file)
+    return joinHyphenatedWordsAux(L)
+
+def removeCharWithOrd(in_file,ord_code,out_file):
+    # Read the file contents
+    with open(in_file, 'r', encoding='utf-8') as file:
+        contents = file.read()
+    # Remove the character with the given ord code
+    filtered_contents = ''.join([char for char in contents if ord(char) != ord_code])
+    # Write the filtered contents back to the file
+    with open(out_file, 'w', encoding='utf-8') as file:
+        file.write(filtered_contents)
+
+def collapseMultipleAdjacentBlanks(input_file, output_file):
+    # Read the content from the input file
+    with open(input_file, 'r') as file:
+        content = file.read()
+    # Replace multiple spaces with a single space
+    collapsed_content = re.sub(r'^\s+', '',content)
+    collapsed_content2 = re.sub(r' +', ' ',collapsed_content)
+    # Write the modified content to the output file
+    with open(output_file, 'w') as file:
+        file.write(collapsed_content2)
+
+def stripLines(file_in,file_out):
+    # Read the file line by line, strip leading white space, and store lines in a list
+    lines =  getLiteralLines(file_in)
+    R = []
+    for l in lines:
+        if l.isspace():
+            R.append(l)
+        else:
+            R.append(l.lstrip())
+    writeFile(R,file_out)        
+
+def yamlToJson(yaml_file):
+    with open(yaml_file, 'r') as file:
+        data = yaml.safe_load(file)
+        return data


### PR DESCRIPTION
The main objective of this PR is to implement a robust version of an Athena TCP server that can accept incoming requests of size up to 4 GB and handle those using native MLton threads instead of forking a separate process. Forking has a distinct disadvantage: it is inherently stateless (since the child process gets its own replica of the global state), so it's not possible to satisfy a client request with side effects (say, a definition, which updates the global environment, or an assertion, which updates the global assumption base), as the side effects will take place on the state of the child process and will vanish when that process completes. 

The new implementation has an improved readAll function. Assuming that the client encodes the length of the payload into the first 4 bytes of its request, the server is guaranteed to read the entire payload properly in a loop. 

A sample Python client is also checked in for convenience. 

This PR also includes: 

(1) A new version of mlton_main.sml that allows for more flexible ways of calling Athena; and
(2) Two scripts, make_athena_binary_for_linux and make_athena_binary_for_mac, that can be used to 
manually compile Athena binaries from the sources. 

